### PR TITLE
Updating specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,41 @@ In addition to the minimum set above, a bindable service **SHOULD** provide:
 The key/value pairs insides this ConfigMap are:
 * A set of `metadata.<property>=<value>` - where `<property>` maps to one of the defined keys for this service, and `<value>` represents the description of the value.  For example, this is useful to define what format the `password` key is in, such as apiKey, basic auth password, token, etc.
 
+#### Making services discoverable
+
+The requirements above allow a bindable service to be discovered and processed by an implementation of this specification (such as the reference implementation, Service Binding Operator).  However, there is a desire for external tools to quickly query a list of bindable services without requiring them to process all of the scenarios outlined in this specification.  With this in mind, a further recommendation for bindable services is to add the following annotation to its bindable resource:
+
+```
+servicebinding/bindable: "true"
+```
+
+As an example, 
+
+```
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: Kafka
+metadata:
+  name: my-cluster
+  annotations:
+    servicebinding/bindable: "true"
+spec:
+   ...
+```
+
+This allows a tool to quickly query k8s resources that have this annotation, and upon finding them they can easily construct the corresponding `services` entry in a `ServiceBinding` CR:
+
+```
+kind: ServiceBinding
+metadata:
+  name: bindind-example
+spec:
+  services:
+    - group: kafka.strimzi.io
+      kind: Kafka
+      resourceRef: my-cluster
+      version: v1aplha1
+...
+```
 
 #### Pointer to binding data
 
@@ -95,7 +130,7 @@ Therefore implementations of this specification **MUST** add the ID prefix to bi
 
 Binding is requested by the consuming application, or an entity on its behalf such as the [Runtime Component Operator](https://github.com/application-stacks/runtime-component-operator), via a custom resource that is applied in the same cluster where an implementation of this specification resides.
 
-Since the reference implementation for most of this specification is the [Service Binding Operator](https://github.com/redhat-developer/service-binding-operator) we will be using the `ServiceBinding` CRD, which resides in [this folder](https://github.com/redhat-developer/service-binding-operator/tree/master/deploy/crds).  
+Since the reference implementation for most of this specification is the [Service Binding Operator](https://github.com/redhat-developer/service-binding-operator) we will be using the `ServiceBinding` CRD, which resides in [this folder](https://github.com/redhat-developer/service-binding-operator/tree/master/deploy/crds), as the entity that holds the binding request.  
 
 **Temporary Note**
 To ensure a better fit with the specification a few modifications have been proposed to the `ServiceBinding` CRD:

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ Main section of the doc.  Has sub-sections that outline the design.
 
 ### Making a service bindable
 
-#### Minimum
-For a service to be bindable it **MUST** comply with one-of:
+#### Minimum requirements for being bindable
+A bindable service **MUST** comply with one-of:
 * provide a Secret and/or ConfigMap that contains the [binding data](#service-binding-schema) and reference this Secret and/or ConfigMap using one of the patterns discussed [below](#pointer-to-binding-data). 
 * map its `status`, `spec`, `data` properties to the corresponding [binding data](#service-binding-schema), using one of the patterns discussed [below](#pointer-to-binding-data).
 * include a sample `ServiceBinding` (see the [Request service binding](#Request-service-binding) section below) in its documentation (e.g. GitHub repository, installation instructions, etc) which contains a `dataMapping` illustrating how each of its `status` properties map to the corresponding [binding data](#service-binding-schema).  This option allows existing services to be bindable with zero code changes.
 
-#### Recommended
+#### Recommended requirements for being bindable
 In addition to the minimum set above, a bindable service **SHOULD** provide:
 * a ConfigMap (which could be the same as the one holding some of the binding data, if applicable) that describes metadata associated with each of the items referenced in the Secret.  The bindable service should also provide a reference to this ConfigMap using one of the patterns discussed [below](#pointer-to-binding-data).
 
@@ -38,7 +38,7 @@ The key/value pairs insides this ConfigMap are:
 
 #### Pointer to binding data
 
-The reference's location and format depends on the following scenarios:
+This specification supports different scenarios for exposing bindable data.  
 
 1. OLM-enabled Operator: Use the `statusDescriptor` and/or `specDescriptor` parts of the CSV to mark which `status` and/or `spec` properties reference the [binding data](#service-binding-schema):
     * The reference's `x-descriptors` with a possible combination of:

--- a/README.md
+++ b/README.md
@@ -35,41 +35,6 @@ In addition to the minimum set above, a bindable service **SHOULD** provide:
 The key/value pairs insides this ConfigMap are:
 * A set of `metadata.<property>=<value>` - where `<property>` maps to one of the defined keys for this service, and `<value>` represents the description of the value.  For example, this is useful to define what format the `password` key is in, such as apiKey, basic auth password, token, etc.
 
-#### Making services discoverable
-
-The requirements above allow a bindable service to be discovered and processed by an implementation of this specification (such as the reference implementation, Service Binding Operator).  However, there is a desire for external tools to quickly query a list of bindable services without requiring them to process all of the scenarios outlined in this specification.  With this in mind, a further recommendation for bindable services is to add the following annotation to its bindable resource:
-
-```
-servicebinding/bindable: "true"
-```
-
-As an example, 
-
-```
-apiVersion: kafka.strimzi.io/v1alpha1
-kind: Kafka
-metadata:
-  name: my-cluster
-  annotations:
-    servicebinding/bindable: "true"
-spec:
-   ...
-```
-
-This allows a tool to quickly query k8s resources that have this annotation, and upon finding them they can easily construct the corresponding `services` entry in a `ServiceBinding` CR:
-
-```
-kind: ServiceBinding
-metadata:
-  name: bindind-example
-spec:
-  services:
-    - group: kafka.strimzi.io
-      kind: Kafka
-      resourceRef: my-cluster
-      version: v1aplha1
-...
-```
 
 #### Pointer to binding data
 


### PR DESCRIPTION
As discussed in today's interlock, this PR adds the following:
* the usage of a service `ID` as a prefix to the binding data being mounted (or optionally injected as env vars by implementations)
