### PR TITLE
Using Go templates for complex mappings

### DIFF
--- a/annotations.md
+++ b/annotations.md
@@ -273,7 +273,7 @@
     Annotation
 
     ```
-    “servicebinding.dev/endpoints”:
+    “servicebinding.dev:
     "path={.status.listeners},elementType=template,source={{GO TEMPLATE}}"
     ```
 


### PR DESCRIPTION
This PR proposes using Go templating for extracting binding information from Kubernetes resources.
The proposed changes are meant to be <kbd>EXPERIMENTAL</kbd> at this point.

Fixes #26 