### PR TITLE
Updating mounting logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,11 +191,11 @@ Where:
 
 Example:  `/platform/bindings/mongo-db/secret/MONGODB_HOST`
 
-#### Cross services data mappings
+#### Custom bindings
 
-The `ServiceBinding` CR allows for the declaration of mappings that are potentially composed of different service bindings (ids).  For this case, the special id of `dataMappings` is reserved and **MUST NOT** be used by any service bindings.  
+The `ServiceBinding` CR allows for the declaration of custom mappings that are potentially composed of different service bindings (ids).  For this case, the special id of `custom-bindings` is reserved and **MUST NOT** be used by any service bindings.  
 
-This means that a container **MAY** have the path `<mountPathPrefix>/dataMappings/secret/<persisted_secret>` mounted, representing all of the composed bindings.  
+This means that a container **MAY** have the path `<mountPathPrefix>/custom-bindings/secret/<persisted_secret>` mounted, representing all of the custom bindings.  
 
 #### Exposing data as environment variables
 

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ However, it is **RECOMMENDED** that implementations expose their intermediate bi
 * a single Secret, whose name matches the corresponding `ServiceBinding` CR's `metadata.name` and resides in the same namespace.  Each item inside this Secret is in the form of either:
   * `<service-id>.secret.<binding-name>: <binding-value>`, representing a single binding item. Example: 
     ```
-    mongo-db/secret/MONGODB_HOST: myhost.com
+    mongo-db.secret.MONGODB_HOST: myhost.com
     ```
   * `<service-id>.metadata.<metadata-name>: <metadata-value>`, representing a single metadata item.  Example:  
     ```

--- a/README.md
+++ b/README.md
@@ -228,11 +228,11 @@ This specification does not mandate a particular methodology for implementations
 However, it is **RECOMMENDED** that implementations expose their intermediate binding representation (i.e. the model containing the binding data prior to mount) in the following way:
 
 * a single Secret, whose name matches the corresponding `ServiceBinding` CR's `metadata.name` and resides in the same namespace.  Each item inside this Secret is in the form of either:
-  * `<service-id>/secret/<binding-name>: <binding-value>`, representing a single binding item. Example: 
+  * `<service-id>.secret.<binding-name>: <binding-value>`, representing a single binding item. Example: 
     ```
     mongo-db/secret/MONGODB_HOST: myhost.com
     ```
-  * `<service-id>/metadata/<metadata-name>: <metadata-value>`, representing a single metadata item.  Example:  
+  * `<service-id>.metadata.<metadata-name>: <metadata-value>`, representing a single metadata item.  Example:  
     ```
     mongo-db/metadata/envVars: |-
       MONGODB_HOST

--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ Partial sample of service-specific mappings:
           value: {{  .status.username }}
 ```
 
+#### <kbd>EXPERIMENTAL</kbd> Synthetic data bindings
+
 If a `dataMappings` requires a cross-service composition then a new synthetic service entry must be created.  
 
 Partial sample of a synthetic / composed mapping:

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Partial sample of a synthetic / composed mapping:
           value: {{  event-user.status.url }} / ?username= {{ event-user.status.username }}
 ```
 
-The special CRD reference with apiVersion `servicebinding/v1alpha1` and kind `ComposedService` is a special CRD whose sole purpose is to compose bindings from other services.  
+The service entry with apiVersion `servicebinding/v1alpha1` and kind `ComposedService` refers to a synthetic CR whose sole purpose is to compose bindings from other services.  
 
 #### Subscription-based services
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ MONGODB_PORT
 
 This specification does not mandate a particular methodology for implementations to process `ServiceBinding` CRs and mount the resulting data as per the requirements set in the previous sections, which allows for different frameworks to have flexibility in exactly how they fulfill the binding request.
 
-However, it is **RECOMMENDED** that implementations expose their intermediate binding representation (i.e. the model containing the binding data prior to mount) in the following way:
+However, it is **RECOMMENDED** that implementations expose their intermediate binding representation (i.e. the model containing the binding data prior to mount) in the following way, so that Operator-based deployments or any other processing unit that owns the deployment can take over the responsibility for mounting the data into the container:
 
 * a single Secret, whose name matches the corresponding `ServiceBinding` CR's `metadata.name` and resides in the same namespace.  Each item inside this Secret is in the form of either:
   * `<service-id>.secret.<binding-name>: <binding-value>`, representing a single binding item. Example: 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Example:  `/platform/bindings/mongo-db/secret/MONGODB_HOST`
 
 #### Custom bindings
 
-The `ServiceBinding` CR allows for the declaration of custom mappings that are potentially composed of different service bindings (ids).  For this case, the special id of `custom-bindings` is reserved and **MUST NOT** be used by any service bindings.  
+The `ServiceBinding` CR allows for the declaration of custom mappings that are potentially composed of different service bindings (ids).  For this case, the `<service-id>` of `custom-bindings` is reserved and **MUST NOT** be used by any service bindings.  
 
 This means that a container **MAY** have the path `<mountPathPrefix>/custom-bindings/secret/<persisted_secret>` mounted, representing all of the custom bindings.  
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Implementations of this specification **MUST** mount the binding data into the c
 ```
 
 Where:
-* `<mountPathPrefix>` defaults to `/platform/bindings` if not specified in the `ServiceBinding` CR via the `mountPathPrefix` element.  The environment variable `SERVICE_BINDINGS_ROOT` **MUST** be set to the value of `<mountPathPrefix>`, so that applications can always find this directory.
+* `<mountPathPrefix>` defaults to `/platform/bindings` if not specified in the `ServiceBinding` CR via the `mountPathPrefix` element.  The environment variable `SERVICE_BINDINGS_ROOT` **MUST** be set to the value of `<mountPathPrefix>`, so that applications can always find this directory, and it is immutable.  This means that if another `ServiceBinding` CR wants to project itself into the same container, it **MUST** reuse the current `SERVICE_BINDINGS_ROOT` value.  
 * `<service-id>` is the `id` field of the corresponding `service` entry in the `ServiceBinding` CR.  If the `id` field is not present, the `name` field is used instead.  The `<service-id>` path **MUST** be unique between the services bound to a particular application.
 * `<persisted_secret>` represents a set of files where the filename is a Secret key and the file contents is the corresponding value of that key.
 

--- a/README.md
+++ b/README.md
@@ -234,8 +234,7 @@ However, it is **RECOMMENDED** that implementations expose their intermediate bi
     ```
   * `<service-id>.metadata.<metadata-name>: <metadata-value>`, representing a single metadata item.  Example:  
     ```
-    mongo-db/metadata/envVars: |-
+    mongo-db.metadata.envVars: |-
       MONGODB_HOST
       MONGODB_PORT
     ```
-

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Implementations of this specification **MUST** mount the binding data into the c
 ```
 
 Where:
-* `<mountPathPrefix>` defaults to `/platform/bindings` if not specified in the `ServiceBinding` CR via the `mountPathPrefix` element.  The environment variable `SERVICE_BINDINGS` **MUST** be set to the value of `<mountPathPrefix>`, so that applications can always find this directory.
+* `<mountPathPrefix>` defaults to `/platform/bindings` if not specified in the `ServiceBinding` CR via the `mountPathPrefix` element.  The environment variable `SERVICE_BINDINGS_ROOT` **MUST** be set to the value of `<mountPathPrefix>`, so that applications can always find this directory.
 * `<service-id>` is the `id` field of the corresponding `service` entry in the `ServiceBinding` CR.  If the `id` field is not present, the `name` field is used instead.  The `<service-id>` path **MUST** be unique between the services bound to a particular application.
 * `<persisted_secret>` represents a set of files where the filename is a Secret key and the file contents is the corresponding value of that key.
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,13 @@ Where:
 * `<service-id>` is the `id` field of the corresponding `service` entry in the `ServiceBinding` CR.  If the `id` field is not present, the `name` field is used instead.  The `<service-id>` path **MUST** be unique between the services bound to a particular application.
 * `<persisted_secret>` represents a set of files where the filename is a Secret key and the file contents is the corresponding value of that key.
 
+Example:  `/platform/bindings/mongo-db/secret/MONGODB_HOST`
+
+#### Cross services data mappings
+
+The `ServiceBinding` CR allows for the declaration of mappings that are potentially composed of different service bindings (ids).  For this case, the special id of `dataMappings` is reserved and **MUST NOT** be used by any service bindings.  
+
+This means that a container **MAY** have the path `<mountPathPrefix>/dataMappings/secret/<persisted_secret>` mounted, representing all of the composed bindings.  
 
 #### Exposing data as environment variables
 
@@ -213,3 +220,22 @@ For example, `platform/bindings/mongodb/metadata/envVars` could have:
 MONGODB_HOST
 MONGODB_PORT
 ```
+
+#### Guidelines for intermediate binding representation
+
+This specification does not mandate a particular methodology for implementations to process `ServiceBinding` CRs and mount the resulting data as per the requirements set in the previous sections, which allows for different frameworks to have flexibility in exactly how they fulfill the binding request.
+
+However, it is **RECOMMENDED** that implementations expose their intermediate binding representation (i.e. the model containing the binding data prior to mount) in the following way:
+
+* a single Secret, whose name matches the corresponding `ServiceBinding` CR's `metadata.name` and resides in the same namespace.  Each item inside this Secret is in the form of either:
+  * `<service-id>/secret/<binding-name>: <binding-value>`, representing a single binding item. Example: 
+    ```
+    mongo-db/secret/MONGODB_HOST: myhost.com
+    ```
+  * `<service-id>/metadata/<metadata-name>: <metadata-value>`, representing a single metadata item.  Example:  
+    ```
+    mongo-db/metadata/envVars: |-
+      MONGODB_HOST
+      MONGODB_PORT
+    ```
+

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Partial sample of a synthetic / composed mapping:
       id: event-stream
       dataMappings:
         - name: EVENT_STREAMS_URL
-          value: {{  event-user.status.url }} / ?username= {{ event-user.status.username }}
+          value: {{  event-cluster.status.url }} / ?username= {{ event-user.status.username }}
 ```
 
 The service entry with apiVersion `servicebinding/v1alpha1` and kind `ComposedService` refers to a synthetic CR whose sole purpose is to compose bindings from other services.  


### PR DESCRIPTION
Updating the mounting logic of the spec.  In the last interlock we decided to mount all of the binding data, to allow for bindings projections into the container without a central coordinator.  

It may be easier to visualize the new text directly from the branch: https://github.com/application-stacks/service-binding-specification/tree/arthurdm-patch-1#mounting-and-injecting-binding-information